### PR TITLE
Filter /help for available commands

### DIFF
--- a/Core/Commands/DefaultCommands.py
+++ b/Core/Commands/DefaultCommands.py
@@ -30,11 +30,15 @@ def think(bot, event, *args):
 
 @DispatcherSingleton.register
 def help(bot, event, command=None, *args):
+    valid_user_commands = []
+    for command_test in sorted(DispatcherSingleton.commands.keys()):
+        if UtilBot.check_if_can_run_command(bot, event, command_test):
+            valid_user_commands.append(command_test)
     docstring = """
     *Current Implemented Commands:*
     {}
     Use: /<command name> ? or /help <command name> to find more information about the command.
-    """.format(', '.join(sorted(DispatcherSingleton.commands.keys())))
+    """.format(', '.join(valid_user_commands))
     if command == '?' or command is None:
         bot.send_message_segments(event.conv, UtilBot.text_to_segments(docstring))
     else:

--- a/Core/Util/UtilBot.py
+++ b/Core/Util/UtilBot.py
@@ -64,6 +64,25 @@ def is_user_admin(bot, user_info, conv_id=None):
     return admins_list and user_id in admins_list
 
 
+def check_if_can_run_command(bot, event, command):
+    commands_admin_list = bot.get_config_suboption(event.conv_id, 'commands_admin')
+    commands_conv_admin_list = bot.get_config_suboption(event.conv_id, 'commands_conversation_admin')
+    admins_list = bot.get_config_suboption(event.conv_id, 'admins')
+    conv_admin = bot.get_config_suboption(event.conv_id, 'conversation_admin')
+
+    # Check if this is a conversation admin command.
+    if commands_conv_admin_list and command in commands_conv_admin_list:
+        if (admins_list and event.user_id[0] not in admins_list) and (
+                    not conv_admin or (event.user_id[0] not in conv_admin)):
+            return False
+
+    # Check if this is a admin-only command.
+    if commands_admin_list and command in commands_admin_list:
+        if not admins_list or event.user_id[0] not in admins_list:
+            return False
+    return True
+    
+
 def get_vote_subject(conv_id):
     if conv_id in _vote_subject:
         return _vote_subject[conv_id]


### PR DESCRIPTION
This code will filter the /help command to show only the commands available to the user.
Had to copy the code for check_if_can_run_command from the MessageHandler object and place into UtilBot.py.  There may be a cleaner way to do this.

This pull request covers issue https://github.com/wardellchandler/HangoutsBot/issues/21 Filter /help for available commands.

Not sure why the last line of each file changed...it may be something my text editor is doing.
